### PR TITLE
Add support for Python 3 with d.items()

### DIFF
--- a/mercury_parser.py
+++ b/mercury_parser.py
@@ -33,8 +33,12 @@ class ParsedArticle(object):
         p = klass(parser=parser)
 
         # Add all values from returned JSON object to instance.
-        for key, value in d.iteritems():
-            setattr(p, key, value)
+        try:
+            for key, value in d.iteritems(): # Python 2
+                setattr(p, key, value)
+        except AttributeError:
+            for key, value in d.items(): # Python 3
+                setattr(p, key, value)
 
         # Proper Datetimes.
         if p.date_published:


### PR DESCRIPTION
I was getting `AttributeError: 'dict' object has no attribute 'iteritems'` when using mercury-parser with Python 3. This fix uses a try/except block to catch the error and use `d.items()` instead of `d.iteritems()`.